### PR TITLE
refactor: Repository Renaming to `ui-kit`

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@
   
   A fully open-source UI library for React, powered by TypeScript and Tailwind CSS. Fast, composable, and ready for production.
 
-[![Stars](https://img.shields.io/github/stars/pittaya-ui/ui?style=for-the-badge&logo=github&color=fb7185)](https://github.com/pittaya-ui/ui)
-[![Contributors](https://img.shields.io/github/contributors/pittaya-ui/ui?style=for-the-badge&logo=github&color=fb7185)](https://github.com/pittaya-ui/ui/graphs/contributors)
-[![License](https://img.shields.io/github/license/pittaya-ui/ui?style=for-the-badge&color=fb7185)](./LICENSE)
-[![Last Commit](https://img.shields.io/github/last-commit/pittaya-ui/ui?style=for-the-badge&color=fb7185)](https://github.com/pittaya-ui/ui/commits/main)
+[![Stars](https://img.shields.io/github/stars/pittaya-ui/ui-kit?style=for-the-badge&logo=github&color=fb7185)](https://github.com/pittaya-ui/ui-kit)
+[![Contributors](https://img.shields.io/github/contributors/pittaya-ui/ui-kit?style=for-the-badge&logo=github&color=fb7185)](https://github.com/pittaya-ui/ui-kit/graphs/contributors)
+[![License](https://img.shields.io/github/license/pittaya-ui/ui-kit?style=for-the-badge&color=fb7185)](./LICENSE)
+[![Last Commit](https://img.shields.io/github/last-commit/pittaya-ui/ui-kit?style=for-the-badge&color=fb7185)](https://github.com/pittaya-ui/ui-kit/commits/main)
 
-[Documentation](https://pittaya-ui.vercel.app/docs) · [Components](https://pittaya-ui.vercel.app/docs) · [Report Bug](https://github.com/pittaya-ui/ui/issues) · [Request Feature](https://github.com/pittaya-ui/ui/issues)
+[Components](https://pittaya-ui.vercel.app/docs/components) · [Report Bug](https://github.com/pittaya-ui/ui-kit/issues) · [Request Feature](https://github.com/pittaya-ui/ui-kit/issues)
 
 </div>
 
@@ -73,8 +73,8 @@ Our mission is to provide developers with production-ready components that are:
 1. **Clone the repository**
 
 ```bash
-git clone https://github.com/pittaya-ui/ui.git
-cd ui
+git clone https://github.com/pittaya-ui/ui-kit.git
+cd ui-kit
 ```
 
 2. **Install dependencies**
@@ -100,7 +100,7 @@ npm run dev
 | ---------- | --------- | -------- | ---------------------------------------- |
 | **Button** | ✅ Stable | Actions  | Accessible button with multiple variants |
 
-> 🚧 More components coming soon! Check our [roadmap](https://github.com/pittaya-ui/ui/issues) for planned features.
+> 🚧 More components coming soon! Check our [roadmap](https://github.com/pittaya-ui/ui-kit/issues) for planned features.
 
 ---
 
@@ -342,7 +342,7 @@ This project is licensed under the **MIT License** - see the [LICENSE](./LICENSE
 
 **GitHub**: [@pittaya-ui](https://github.com/pittaya-ui)
 
-**Issues**: [Report a bug or request a feature](https://github.com/pittaya-ui/ui/issues)
+**Issues**: [Report a bug or request a feature](https://github.com/pittaya-ui/ui-kit/issues)
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "pittaya-ui",
+  "name": "pittaya-ui-kit",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "pittaya-ui",
+      "name": "pittaya-ui-kit",
       "version": "0.1.0",
       "dependencies": {
         "@radix-ui/react-separator": "^1.1.7",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pittaya-ui",
+  "name": "pittaya-ui-kit",
   "version": "0.1.0",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
## 📝 Pull Request — Repository Renaming to `ui-kit`

This pull request updates the project to reflect the new repository name **`ui-kit`** (previously `ui`) across all documentation and configuration files.  
The goal is to ensure **consistency, accuracy, and clarity** for contributors and users.

---

### 🏷️ Repository & Package Renaming

- 🔄 Updated project name in `package.json`  
  → `pittaya-ui` ➜ `pittaya-ui-kit`

---

### 📚 Documentation Updates

- 🪄 Updated all badges and links in `README.md` to point to the correct repository:
  - ⭐ Stars  
  - 👥 Contributors  
  - 🪪 License  
  - 🕒 Last Commit
- 📦 Updated clone and setup instructions to use the new repo URL and directory name.
- 🗺️ Adjusted roadmap and issue tracker links to reference `ui-kit` instead of `ui`.  
  [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L103-R103)  
  [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L345-R345)
