### PR TITLE
feat: add `announcement badge` component

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,28 @@
+import { ArrowUpRight, Bell } from "lucide-react";
+import Link from "next/link";
+
 import { PittayaBackground } from "@/components/raycast-animated-background";
+import {
+  AnnouncementContainer,
+  AnnouncementIcon,
+  AnnouncementSeparator,
+  AnnouncementText,
+  AnnouncementTitle,
+} from "@/components/ui/announcement-badge";
 
 export default function Home() {
   return (
     <PittayaBackground className="h-screen max-h-screen overflow-x-hidden overflow-y-hidden">
       <main className="flex h-screen flex-1 flex-col items-center justify-center gap-10 px-6">
+        <Link href={"/docs/components"}>
+          <AnnouncementContainer variant={"default"}>
+            <AnnouncementIcon icon={"🎉"} />
+            <AnnouncementSeparator className="bg-white/30" />
+            <AnnouncementTitle>
+              Introducing Pittaya UI <ArrowUpRight className="size-4" />
+            </AnnouncementTitle>
+          </AnnouncementContainer>
+        </Link>
         <div className="max-w-4xl space-y-8 text-center">
           <h1 className="text-6xl leading-tight font-bold text-white [text-shadow:0_0_20px_rgba(255,255,255,0.6)]">
             Components that scale <br />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,4 @@
-import { ArrowUpRight, Bell } from "lucide-react";
+import { ArrowUpRight } from "lucide-react";
 import Link from "next/link";
 
 import { PittayaBackground } from "@/components/raycast-animated-background";
@@ -6,7 +6,6 @@ import {
   AnnouncementContainer,
   AnnouncementIcon,
   AnnouncementSeparator,
-  AnnouncementText,
   AnnouncementTitle,
 } from "@/components/ui/announcement-badge";
 
@@ -15,7 +14,7 @@ export default function Home() {
     <PittayaBackground className="h-screen max-h-screen overflow-x-hidden overflow-y-hidden">
       <main className="flex h-screen flex-1 flex-col items-center justify-center gap-10 px-6">
         <Link href={"/docs/components"}>
-          <AnnouncementContainer variant={"default"}>
+          <AnnouncementContainer variant={"glassEffect"}>
             <AnnouncementIcon icon={"🎉"} />
             <AnnouncementSeparator className="bg-white/30" />
             <AnnouncementTitle>

--- a/src/components/docs/contents/announcement-badge.tsx
+++ b/src/components/docs/contents/announcement-badge.tsx
@@ -186,7 +186,7 @@ export function BadgeAnnouncement() {
 export function TextBadgeAnnouncement() {
   return (
     <AnnouncementContainer>
-      <AnnouncementText text="coming soon" />
+      <AnnouncementText text="soon" />
       <AnnouncementSeparator />
       <AnnouncementTitle>Product Hunt launch is live</AnnouncementTitle>
     </AnnouncementContainer>
@@ -194,7 +194,7 @@ export function TextBadgeAnnouncement() {
 }`,
       preview: (
         <AnnouncementContainer>
-          <AnnouncementText text="coming soon" />
+          <AnnouncementText text="soon" />
           <AnnouncementSeparator />
           <AnnouncementTitle>Product Hunt launch is live</AnnouncementTitle>
         </AnnouncementContainer>
@@ -272,14 +272,14 @@ export function GlassAnnouncement() {
   );
 }`,
       preview: (
-        <div className="relative flex items-center justify-center rounded-lg bg-gradient-to-br from-purple-500 via-pink-500 to-orange-500 p-8">
+        <div className="relative flex items-center justify-center rounded-lg bg-gradient-to-br from-purple-500 via-pink-500 to-orange-500 p-2">
           <AnnouncementContainer
             variant="glassEffect"
             className="cursor-pointer transition-opacity hover:opacity-80"
           >
             <AnnouncementIcon icon="🚀" />
             <AnnouncementSeparator />
-            <AnnouncementTitle>
+            <AnnouncementTitle className="w-full">
               Try our new dashboard
               <ArrowRight className="size-4" />
             </AnnouncementTitle>

--- a/src/components/docs/contents/announcement-badge.tsx
+++ b/src/components/docs/contents/announcement-badge.tsx
@@ -1,4 +1,4 @@
-import { ArrowRight, ArrowUpRight, Megaphone, Package } from "lucide-react";
+import { ArrowRight, ArrowUpRight, Megaphone } from "lucide-react";
 
 import {
   AnnouncementContainer,
@@ -145,19 +145,20 @@ export const announcementBadgeDoc: ComponentDoc = {
       code: `import {
   AnnouncementContainer,
   AnnouncementSeparator,
-  AnnouncementText,
+  AnnouncementIcon,
   AnnouncementTitle,
 } from "@/components/ui/announcement-badge";
+import { Megaphone } from "lucide-react";
 
 export function BadgeAnnouncement() {
   return (
-        <AnnouncementContainer variant={"default"}>
-          <AnnouncementIcon icon={Megaphone} />
-          <AnnouncementSeparator className="bg-white/30" />
-          <AnnouncementTitle>
-            Introducing Pittaya UI <ArrowUpRight className="size-4" />
-          </AnnouncementTitle>
-        </AnnouncementContainer>
+    <AnnouncementContainer variant={"default"}>
+      <AnnouncementIcon icon={Megaphone} />
+      <AnnouncementSeparator className="bg-white/30" />
+      <AnnouncementTitle>
+        Introducing Pittaya UI <ArrowUpRight className="size-4" />
+      </AnnouncementTitle>
+    </AnnouncementContainer>
   );
 }`,
       preview: (

--- a/src/components/docs/contents/announcement-badge.tsx
+++ b/src/components/docs/contents/announcement-badge.tsx
@@ -1,0 +1,337 @@
+import { ArrowRight, ArrowUpRight, Megaphone, Package } from "lucide-react";
+
+import {
+  AnnouncementContainer,
+  AnnouncementIcon,
+  AnnouncementSeparator,
+  AnnouncementText,
+  AnnouncementTitle,
+} from "@/components/ui/announcement-badge";
+import type { ComponentDoc } from "@/lib/docs/types";
+
+export const announcementBadgeDoc: ComponentDoc = {
+  slug: "announcement-badge",
+  metadata: {
+    name: "Announcement Badge",
+    description:
+      "A flexible composite component for displaying announcements, updates, and badges with icons, text, and separators.",
+    category: "Components",
+    status: "stable",
+  },
+  sections: [
+    {
+      id: "when-to-use",
+      title: "When to use",
+      level: 2,
+      content: (
+        <div className="text-muted-foreground space-y-4 text-base leading-relaxed">
+          <p>
+            Use the Announcement Badge to highlight new features, product
+            updates, or important notifications in a compact and visually
+            appealing format.
+          </p>
+          <p>
+            This component works best in hero sections, above navigation bars,
+            or at the top of content areas where you need to draw attention
+            without being intrusive.
+          </p>
+        </div>
+      ),
+    },
+    {
+      id: "best-practices",
+      title: "Best practices",
+      level: 2,
+      content: (
+        <div className="text-muted-foreground space-y-4 text-base leading-relaxed">
+          <ul className="list-disc space-y-2 pl-5">
+            <li>
+              Keep announcement text concise and actionable—aim for 3-5 words
+              maximum.
+            </li>
+            <li>
+              Use the <code>glassEffect</code> variant when placing the badge
+              over images or gradient backgrounds.
+            </li>
+            <li>
+              Combine icons with text to quickly communicate the nature of the
+              announcement (e.g., 🎉 for launches, 🚀 for new features).
+            </li>
+            <li>
+              Use <code>AnnouncementSeparator</code> to create visual hierarchy
+              between different pieces of information.
+            </li>
+          </ul>
+        </div>
+      ),
+    },
+    {
+      id: "accessibility",
+      title: "Accessibility",
+      level: 2,
+      content: (
+        <div className="text-muted-foreground space-y-4 text-base leading-relaxed">
+          <p>
+            The component uses semantic HTML with proper contrast ratios for
+            text and borders. When using icons alone, ensure you provide
+            descriptive text alternatives for screen readers.
+          </p>
+          <p>
+            If the announcement is clickable or interactive, wrap it in a proper
+            button or link element with clear labeling to communicate the action
+            to assistive technologies.
+          </p>
+        </div>
+      ),
+    },
+  ],
+  props: [
+    {
+      name: "AnnouncementContainer",
+      type: "component",
+      description:
+        "The main wrapper component that holds all announcement elements.",
+    },
+    {
+      name: "variant",
+      type: '"default" | "glassEffect"',
+      defaultValue: '"default"',
+      description:
+        "Controls the background style. Use glassEffect for transparent backgrounds with backdrop blur.",
+    },
+    {
+      name: "AnnouncementText",
+      type: "component",
+      description:
+        "Displays highlighted text in a badge format with background and border.",
+    },
+    {
+      name: "text",
+      type: "string",
+      required: true,
+      description: "The text content to display inside the badge.",
+    },
+    {
+      name: "AnnouncementIcon",
+      type: "component",
+      description:
+        "Displays an icon from lucide-react or a string (like emoji).",
+    },
+    {
+      name: "icon",
+      type: "LucideIcon | string",
+      required: true,
+      description:
+        "The icon to display. Can be a Lucide icon component or a string (emoji).",
+    },
+    {
+      name: "AnnouncementSeparator",
+      type: "component",
+      description:
+        "A vertical divider to separate different sections of the announcement.",
+    },
+    {
+      name: "AnnouncementTitle",
+      type: "component",
+      description: "The main title or description text of the announcement.",
+    },
+  ],
+  examples: [
+    {
+      id: "with-icon",
+      title: "With icon",
+      description:
+        "Use AnnouncementText before the separator to highlight a status or category.",
+      code: `import {
+  AnnouncementContainer,
+  AnnouncementSeparator,
+  AnnouncementText,
+  AnnouncementTitle,
+} from "@/components/ui/announcement-badge";
+
+export function BadgeAnnouncement() {
+  return (
+        <AnnouncementContainer variant={"default"}>
+          <AnnouncementIcon icon={Megaphone} />
+          <AnnouncementSeparator className="bg-white/30" />
+          <AnnouncementTitle>
+            Introducing Pittaya UI <ArrowUpRight className="size-4" />
+          </AnnouncementTitle>
+        </AnnouncementContainer>
+  );
+}`,
+      preview: (
+        <AnnouncementContainer variant={"default"}>
+          <AnnouncementIcon icon={Megaphone} />
+          <AnnouncementSeparator className="bg-white/30" />
+          <AnnouncementTitle>
+            Introducing Pittaya UI <ArrowUpRight className="size-4" />
+          </AnnouncementTitle>
+        </AnnouncementContainer>
+      ),
+    },
+    {
+      id: "with-text-badge",
+      title: "With text badge",
+      description:
+        "Use AnnouncementText before the separator for a more visual approach.",
+      code: `import {
+  AnnouncementContainer,
+  AnnouncementText,
+  AnnouncementSeparator,
+  AnnouncementTitle,
+} from "@/components/ui/announcement-badge";
+
+export function TextBadgeAnnouncement() {
+  return (
+    <AnnouncementContainer>
+      <AnnouncementText text="coming soon" />
+      <AnnouncementSeparator />
+      <AnnouncementTitle>Product Hunt launch is live</AnnouncementTitle>
+    </AnnouncementContainer>
+  );
+}`,
+      preview: (
+        <AnnouncementContainer>
+          <AnnouncementText text="coming soon" />
+          <AnnouncementSeparator />
+          <AnnouncementTitle>Product Hunt launch is live</AnnouncementTitle>
+        </AnnouncementContainer>
+      ),
+    },
+    {
+      id: "with-link",
+      title: "Interactive with link",
+      description:
+        "Make the announcement clickable by wrapping it in a link, with an arrow icon at the end.",
+      code: `import { ArrowRight } from "lucide-react";
+import Link from "next/link";
+import {
+  AnnouncementContainer,
+  AnnouncementIcon,
+  AnnouncementSeparator,
+  AnnouncementText,
+  AnnouncementTitle,
+} from "@/components/ui/announcement-badge";
+
+export function LinkAnnouncement() {
+  return (
+    <Link href="/recife">
+      <AnnouncementContainer className="cursor-pointer transition-opacity hover:opacity-80">
+        <AnnouncementText text="v2.0" />
+        <AnnouncementSeparator />
+        <AnnouncementTitle>
+          Read our launch post
+          <ArrowRight className="size-4" />
+        </AnnouncementTitle>
+      </AnnouncementContainer>
+    </Link>
+  );
+}`,
+      preview: (
+        <AnnouncementContainer className="cursor-pointer transition-opacity hover:opacity-80">
+          <AnnouncementText text="v2.0" />
+          <AnnouncementSeparator />
+          <AnnouncementTitle>
+            Read our launch post
+            <ArrowUpRight className="size-4" />
+          </AnnouncementTitle>
+        </AnnouncementContainer>
+      ),
+    },
+    {
+      id: "glass-effect",
+      title: "Glass effect variant",
+      description:
+        "Use the glass effect variant for announcements over images or gradients.",
+      code: `import { ArrowRight } from "lucide-react";
+import Link from "next/link";
+import {
+  AnnouncementContainer,
+  AnnouncementIcon,
+  AnnouncementSeparator,
+  AnnouncementTitle,
+} from "@/components/ui/announcement-badge";
+
+export function GlassAnnouncement() {
+  return (
+    <Link href="/beta">
+      <AnnouncementContainer 
+        variant="glassEffect"
+        className="cursor-pointer transition-opacity hover:opacity-80"
+      >
+        <AnnouncementIcon icon="🚀" />
+        <AnnouncementSeparator />
+        <AnnouncementTitle>
+          Try our new dashboard
+          <ArrowRight className="size-4" />
+        </AnnouncementTitle>
+      </AnnouncementContainer>
+    </Link>
+  );
+}`,
+      preview: (
+        <div className="relative flex items-center justify-center rounded-lg bg-gradient-to-br from-purple-500 via-pink-500 to-orange-500 p-8">
+          <AnnouncementContainer
+            variant="glassEffect"
+            className="cursor-pointer transition-opacity hover:opacity-80"
+          >
+            <AnnouncementIcon icon="🚀" />
+            <AnnouncementSeparator />
+            <AnnouncementTitle>
+              Try our new dashboard
+              <ArrowRight className="size-4" />
+            </AnnouncementTitle>
+          </AnnouncementContainer>
+        </div>
+      ),
+    },
+    {
+      id: "with-emoji",
+      title: "With Emoji",
+      description: "Use Emoji for more design consistency and flexibility.",
+      code: `
+import {
+  AnnouncementContainer,
+  AnnouncementIcon,
+  AnnouncementSeparator,
+  AnnouncementTitle,
+} from "@/components/ui/announcement-badge";
+ 
+import Link from "next/link";
+
+export function LucideAnnouncement() {
+  return (
+    <Link href="https://example.com" target="_blank" rel="noopener noreferrer">
+      <AnnouncementContainer className="cursor-pointer transition-opacity hover:opacity-80">
+        <AnnouncementIcon icon="✨" />
+        <AnnouncementSeparator />
+        <AnnouncementTitle>
+          Performance improvements
+        <ArrowUpRight className="size-4" />
+        </AnnouncementTitle>
+      </AnnouncementContainer>
+    </Link>
+  );
+}`,
+      preview: (
+        <AnnouncementContainer className="cursor-pointer transition-opacity hover:opacity-80">
+          <AnnouncementIcon icon="✨" />
+          <AnnouncementSeparator />
+          <AnnouncementTitle>
+            Performance improvements
+            <ArrowUpRight className="size-4" />
+          </AnnouncementTitle>
+        </AnnouncementContainer>
+      ),
+    },
+  ],
+  toc: [
+    { id: "installation", title: "Installation", level: 2 },
+    { id: "when-to-use", title: "When to use", level: 2 },
+    { id: "best-practices", title: "Best practices", level: 2 },
+    { id: "accessibility", title: "Accessibility", level: 2 },
+    { id: "examples", title: "Examples", level: 2 },
+    { id: "properties", title: "Properties", level: 2 },
+  ],
+};

--- a/src/components/ui/announcement-badge.tsx
+++ b/src/components/ui/announcement-badge.tsx
@@ -18,37 +18,69 @@ const announcementContainerVariants = cva(
   }
 );
 
-
-
-export function AnnouncementContainer({ className, variant, ...props }: React.ComponentProps<"div"> & VariantProps<typeof announcementContainerVariants>) {
+export function AnnouncementContainer({
+  className,
+  variant,
+  ...props
+}: React.ComponentProps<"div"> &
+  VariantProps<typeof announcementContainerVariants>) {
   return (
     <div
-    className={announcementContainerVariants({ variant, className })}
-    {...props}
+      className={announcementContainerVariants({ variant, className })}
+      {...props}
     />
   );
 }
 
 export function AnnouncementSeparator({ className }: { className?: string }) {
-  return <div className={cn("h-5 w-px bg-accent", className)} />;
+  return <div className={cn("bg-accent h-5 w-px", className)} />;
 }
 
-export function AnnouncementText({ className, text}: React.ComponentProps<"div"> & {text: string}) {
-  return <div className={cn("text-sm font-medium px-2 py-1 rounded-full bg-accent border border-border", className)}>
-    <p>{text}</p>
-    </div>
-}
-
-export function AnnouncementIcon({ className, icon: Icon }: { className?: string, icon: LucideIcon | string }) {
-
+export function AnnouncementText({
+  className,
+  text,
+}: React.ComponentProps<"div"> & { text: string }) {
   return (
-    <div className="px-2">
-      {typeof Icon === "string" ? <p className={cn("text-sm font-medium", className)}>{Icon}</p> : <Icon className={cn("size-4 ", className)} />}
+    <div
+      className={cn(
+        "bg-accent border-border rounded-full border px-2 py-1 text-sm font-medium",
+        className
+      )}
+    >
+      <p>{text}</p>
     </div>
   );
 }
 
-export function AnnouncementTitle({ className, ...props }: React.ComponentProps<"h3">) {
-  return <h3 className={cn("text-sm font-medium px-2 py-1 flex items-center gap-2", className)} {...props} />;
+export function AnnouncementIcon({
+  className,
+  icon: Icon,
+}: {
+  className?: string;
+  icon: LucideIcon | string;
+}) {
+  return (
+    <div className="px-2">
+      {typeof Icon === "string" ? (
+        <p className={cn("text-sm font-medium", className)}>{Icon}</p>
+      ) : (
+        <Icon className={cn("size-4", className)} />
+      )}
+    </div>
+  );
 }
 
+export function AnnouncementTitle({
+  className,
+  ...props
+}: React.ComponentProps<"h3">) {
+  return (
+    <h3
+      className={cn(
+        "flex items-center gap-2 px-2 py-1 text-sm font-medium",
+        className
+      )}
+      {...props}
+    />
+  );
+}

--- a/src/components/ui/announcement-badge.tsx
+++ b/src/components/ui/announcement-badge.tsx
@@ -1,0 +1,54 @@
+import { cva, VariantProps } from "class-variance-authority";
+import { type LucideIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+const announcementContainerVariants = cva(
+  "flex items-center justify-between gap-2 w-fit bg-background rounded-full px-1 py-0.5 border border-border shadow-sm hover:shadow-md transition-shadow ",
+  {
+    variants: {
+      variant: {
+        glassEffect: "bg-background/50 backdrop-blur-sm hover:bg-background/70",
+        default: "bg-background hover:bg-background/80",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+);
+
+
+
+export function AnnouncementContainer({ className, variant, ...props }: React.ComponentProps<"div"> & VariantProps<typeof announcementContainerVariants>) {
+  return (
+    <div
+    className={announcementContainerVariants({ variant, className })}
+    {...props}
+    />
+  );
+}
+
+export function AnnouncementSeparator({ className }: { className?: string }) {
+  return <div className={cn("h-5 w-px bg-accent", className)} />;
+}
+
+export function AnnouncementText({ className, text}: React.ComponentProps<"div"> & {text: string}) {
+  return <div className={cn("text-sm font-medium px-2 py-1 rounded-full bg-accent border border-border", className)}>
+    <p>{text}</p>
+    </div>
+}
+
+export function AnnouncementIcon({ className, icon: Icon }: { className?: string, icon: LucideIcon | string }) {
+
+  return (
+    <div className="px-2">
+      {typeof Icon === "string" ? <p className={cn("text-sm font-medium", className)}>{Icon}</p> : <Icon className={cn("size-4 ", className)} />}
+    </div>
+  );
+}
+
+export function AnnouncementTitle({ className, ...props }: React.ComponentProps<"h3">) {
+  return <h3 className={cn("text-sm font-medium px-2 py-1 flex items-center gap-2", className)} {...props} />;
+}
+

--- a/src/lib/docs/component-details.tsx
+++ b/src/lib/docs/component-details.tsx
@@ -1,3 +1,4 @@
+import { announcementBadgeDoc } from "@/components/docs/contents/announcement-badge";
 import { buttonDoc } from "@/components/docs/contents/button";
 import { installationSectionDoc } from "@/components/docs/contents/installation-section";
 import { orbitImagesDoc } from "@/components/docs/contents/orbit-images";
@@ -8,6 +9,7 @@ const docs: Record<string, ComponentDoc> = {
   [buttonDoc.slug]: buttonDoc,
   [installationSectionDoc.slug]: installationSectionDoc,
   [orbitImagesDoc.slug]: orbitImagesDoc,
+  [announcementBadgeDoc.slug]: announcementBadgeDoc,
 };
 
 export function getComponentDoc(slug: string): ComponentDoc | undefined {

--- a/src/lib/docs/component-details.tsx
+++ b/src/lib/docs/component-details.tsx
@@ -7,11 +7,11 @@ import { orbitImagesDoc } from "@/components/docs/contents/orbit-images";
 import type { ComponentDoc } from "./types";
 
 const docs: Record<string, ComponentDoc> = {
+  [announcementBadgeDoc.slug]: announcementBadgeDoc,
   [buttonDoc.slug]: buttonDoc,
   [copyButtonDoc.slug]: copyButtonDoc,
   [installationSectionDoc.slug]: installationSectionDoc,
   [orbitImagesDoc.slug]: orbitImagesDoc,
-  [announcementBadgeDoc.slug]: announcementBadgeDoc,
 };
 
 export function getComponentDoc(slug: string): ComponentDoc | undefined {

--- a/src/lib/docs/components-index.ts
+++ b/src/lib/docs/components-index.ts
@@ -2,6 +2,14 @@ import type { ComponentIndexItem } from "./types";
 
 export const componentsIndex: ComponentIndexItem[] = [
   {
+    slug: "announcement-badge",
+    name: "Announcement Badge",
+    description: "Displays a badge with an icon and a title.",
+    category: "Components",
+    status: "stable",
+    tags: ["badge", "announcement", "alert"],
+  },
+  {
     slug: "button",
     name: "Button",
     description: "Displays a button or a component that looks like a button.",


### PR DESCRIPTION
This pull request introduces a new, reusable **Announcement Badge** component along with full documentation, making it easy to display announcements, updates, or badges with icons, text, and separators. The changes include the component implementation, comprehensive usage docs, and integration into the documentation system and component index.

---

### **Announcement Badge Component Implementation**
- Added `AnnouncementContainer`, `AnnouncementIcon`, `AnnouncementSeparator`, `AnnouncementText`, and `AnnouncementTitle` components in  
  `src/components/ui/announcement-badge.tsx`, supporting variants and flexible icon/text composition.

---

### **Documentation and Examples**
- Created detailed documentation for the Announcement Badge in  
  `src/components/docs/contents/announcement-badge.tsx`, including:
  - Usage guidelines  
  - Accessibility notes  
  - Props reference  
  - Multiple interactive examples demonstrating different configurations

---

### **Integration with the Documentation System**
- Registered the new documentation in `src/lib/docs/component-details.tsx` and added it to the documentation record.  
- Added the Announcement Badge to the component index in `src/lib/docs/components-index.ts` for visibility within the docs UI.

---

### **Usage on the Main Page**
- Implemented an example of the Announcement Badge in the homepage (`src/app/page.tsx`), demonstrating how it can be used to highlight new features or announcements.
