### PR TITLE
✨ Feat: Component Docs — Previous/Next Navigation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1428,7 +1428,6 @@
       "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.4.0.tgz",
       "integrity": "sha512-k4iu1R6e5D54918V4sqmISUkI5OgTw3v7/sDRKEC632Wd5g2WBtUS5gyG63X0GJO/HZUj1tsjSXfyzwrUHZl1g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.17.8",
         "@types/react-reconciler": "^0.32.0",
@@ -1879,7 +1878,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.10.tgz",
       "integrity": "sha512-EhBeSYX0Y6ye8pNebpKrwFJq7BoQ8J5SO6NlvNwwHjSj6adXJViPQrKlsyPw7hLBLvckEMO1yxeGdR82YBBlDg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -1890,7 +1888,6 @@
       "integrity": "sha512-i5ZzwYpqjmrKenzkoLM2Ibzt6mAsM7pxB6BCIouEVVmgiqaMj1TjaK7hnA36hbW5aZv20kx7Lw6hWzPWg0Rurw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -1925,7 +1922,6 @@
       "resolved": "https://registry.npmjs.org/@types/three/-/three-0.181.0.tgz",
       "integrity": "sha512-MLF1ks8yRM2k71D7RprFpDb9DOX0p22DbdPqT/uAkc6AtQXjxWCVDjCy23G9t1o8HcQPk7woD2NIyiaWcWPYmA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dimforge/rapier3d-compat": "~0.12.0",
         "@tweenjs/tween.js": "~23.1.3",
@@ -1994,7 +1990,6 @@
       "integrity": "sha512-pUXGCuHnnKw6PyYq93lLRiZm3vjuslIy7tus1lIQTYVK9bL8XBgJnCWm8a0KcTtHC84Yya1Q6rtll+duSMj0dg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.39.1",
         "@typescript-eslint/types": "8.39.1",
@@ -2609,7 +2604,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3678,7 +3672,6 @@
       "integrity": "sha512-TS9bTNIryDzStCpJN93aC5VRSW3uTx9sClUn4B87pwiCaJh220otoI0X8mJKr+VcPtniMdN8GKjlwgWGUv5ZKA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3853,7 +3846,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5852,7 +5844,6 @@
       "resolved": "https://registry.npmjs.org/next/-/next-15.4.6.tgz",
       "integrity": "sha512-us++E/Q80/8+UekzB3SAGs71AlLDsadpFMXVNM/uQ0BMwsh9m3mr0UNQIfjKed8vpWXsASe+Qifrnu1oLIcKEQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@next/env": "15.4.6",
         "@swc/helpers": "0.5.15",
@@ -6276,7 +6267,6 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -6454,7 +6444,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6464,7 +6453,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -7291,8 +7279,7 @@
       "version": "0.181.1",
       "resolved": "https://registry.npmjs.org/three/-/three-0.181.1.tgz",
       "integrity": "sha512-bz9xZUQMw3pJbjKy7roiwXWgAp+oVUa+4k5o0oBAQ+IFJuru1xzvtk63h6k72XZanXS/SgoEhV6927Vgazyq2w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/three-mesh-bvh": {
       "version": "0.8.3",
@@ -7367,7 +7354,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7603,7 +7589,6 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/app/docs/components/[slug]/page.tsx
+++ b/src/app/docs/components/[slug]/page.tsx
@@ -2,9 +2,11 @@ import { Metadata } from "next";
 import { notFound } from "next/navigation";
 
 import { ComponentContent } from "@/components/docs/component-content";
+import { ComponentsNavigation } from "@/components/docs/components-navigation";
 import { DocsShell } from "@/components/docs/docs-shell";
 import { SidebarGeneral } from "@/components/docs/sidebar-general";
 import { SidebarLocal } from "@/components/docs/sidebar-local";
+import { getAdjacentItems } from "@/helpers/navigation";
 import {
   getAllComponentDocs,
   getComponentDoc,
@@ -51,12 +53,15 @@ export default async function ComponentDocsPage({ params }: PageProps) {
 
   const index = getComponentsIndex();
 
+  const { previous, next } = getAdjacentItems(index, slug);
+
   return (
     <DocsShell
       sidebar={<SidebarGeneral items={index} activeSlug={slug} />}
       secondarySidebar={<SidebarLocal toc={doc.toc} />}
     >
       <ComponentContent doc={doc} />
+      <ComponentsNavigation previous={previous} next={next} />
     </DocsShell>
   );
 }

--- a/src/components/docs/components-navigation.tsx
+++ b/src/components/docs/components-navigation.tsx
@@ -1,0 +1,59 @@
+import { ArrowLeft, ArrowRight } from "lucide-react";
+import Link from "next/link";
+
+import { cn } from "@/lib/utils";
+
+import { Button } from "../ui/button";
+
+interface ComponentsNavigationProps {
+  previous?: {
+    slug: string;
+    name: string;
+  };
+  next?: {
+    slug: string;
+    name: string;
+  };
+}
+
+export function ComponentsNavigation({
+  previous,
+  next,
+}: ComponentsNavigationProps) {
+  return (
+    <footer className="mt-10 flex w-full items-center justify-between">
+      <div className="flex h-full items-center gap-2">
+        <Button
+          variant="outline"
+          asChild
+          disabled={!previous}
+          className={cn(!previous && "hidden")}
+        >
+          <Link
+            href={`/docs/components/${previous?.slug}`}
+            className="group flex items-center gap-2"
+          >
+            <ArrowLeft className="h-4 w-4 transition-transform duration-300 group-hover:-translate-x-1" />
+            {previous?.name}
+          </Link>
+        </Button>
+      </div>
+      <div className="flex items-center gap-2">
+        <Button
+          variant="outline"
+          asChild
+          disabled={!next}
+          className={cn(!next && "hidden")}
+        >
+          <Link
+            href={`/docs/components/${next?.slug}`}
+            className="group flex items-center gap-2"
+          >
+            {next?.name}
+            <ArrowRight className="h-4 w-4 transition-transform duration-300 group-hover:translate-x-1" />
+          </Link>
+        </Button>
+      </div>
+    </footer>
+  );
+}

--- a/src/helpers/navigation.ts
+++ b/src/helpers/navigation.ts
@@ -1,0 +1,24 @@
+import type { ComponentIndexItem } from "@/lib/docs/types";
+
+interface AdjacentItems {
+  previous: ComponentIndexItem | undefined;
+  next: ComponentIndexItem | undefined;
+}
+
+/**
+ * Finds the previous and next items in a list based on the current slug
+ * @param items - Array of ComponentIndexItem
+ * @param currentSlug - Current item slug
+ * @returns Object containing the previous and next item
+ */
+export function getAdjacentItems(
+  items: ComponentIndexItem[],
+  currentSlug: string
+): AdjacentItems {
+  const currentIndex = items.findIndex((item) => item.slug === currentSlug);
+
+  return {
+    previous: items[currentIndex - 1],
+    next: items[currentIndex + 1],
+  };
+}


### PR DESCRIPTION
## 📄✨ Component Docs — Previous/Next Navigation

This PR introduces seamless navigation between component documentation pages, making it easier for users to browse components in sequence.

---

## 🧭 New Documentation Navigation System

### 🔧 Helper: `getAdjacentItems`
- Added to `src/helpers/navigation.ts`
- Determines the **previous** and **next** components based on the current slug
- Provides clean, reusable navigation logic

### 🧩 UI Component: `ComponentsNavigation`
- Added `src/components/docs/components-navigation.tsx`
- Displays navigation buttons with icons and labels
- Helps users move smoothly between component docs

### 🔗 Page Integration
Updated `src/app/docs/components/[slug]/page.tsx` to:
- Import `getAdjacentItems` and `ComponentsNavigation`
- Pass adjacent navigation data directly to the navigation component
- Enable contextual next/previous navigation based on current page

---
