### PR TITLE
🎨 Refactor: Examples Import Path Updates

### DIFF
--- a/src/components/docs/contents/announcement-badge.tsx
+++ b/src/components/docs/contents/announcement-badge.tsx
@@ -147,7 +147,7 @@ export const announcementBadgeDoc: ComponentDoc = {
   AnnouncementSeparator,
   AnnouncementIcon,
   AnnouncementTitle,
-} from "@/components/ui/announcement-badge";
+} from "@/components/pittaya/ui/announcement-badge";
 import { Megaphone } from "lucide-react";
 
 export function BadgeAnnouncement() {
@@ -181,7 +181,7 @@ export function BadgeAnnouncement() {
   AnnouncementText,
   AnnouncementSeparator,
   AnnouncementTitle,
-} from "@/components/ui/announcement-badge";
+} from "@/components/pittaya/ui/announcement-badge";
 
 export function TextBadgeAnnouncement() {
   return (
@@ -213,7 +213,7 @@ import {
   AnnouncementSeparator,
   AnnouncementText,
   AnnouncementTitle,
-} from "@/components/ui/announcement-badge";
+} from "@/components/pittaya/ui/announcement-badge";
 
 export function LinkAnnouncement() {
   return (
@@ -252,7 +252,7 @@ import {
   AnnouncementIcon,
   AnnouncementSeparator,
   AnnouncementTitle,
-} from "@/components/ui/announcement-badge";
+} from "@/components/pittaya/ui/announcement-badge";
 
 export function GlassAnnouncement() {
   return (
@@ -297,7 +297,7 @@ import {
   AnnouncementIcon,
   AnnouncementSeparator,
   AnnouncementTitle,
-} from "@/components/ui/announcement-badge";
+} from "@/components/pittaya/ui/announcement-badge";
  
 import Link from "next/link";
 

--- a/src/components/docs/contents/button.tsx
+++ b/src/components/docs/contents/button.tsx
@@ -102,7 +102,7 @@ export const buttonDoc: ComponentDoc = {
       title: "Default variants",
       description:
         "Demonstration of available variants to communicate action hierarchy.",
-      code: `import { Button } from "@/components/ui/button";
+      code: `import { Button } from "@/components/pittaya/ui/button";
 
 export function ButtonVariants() {
   return (
@@ -132,7 +132,7 @@ export function ButtonVariants() {
       title: "With icon",
       description: "Use icons to reinforce context when space is limited.",
       code: `import { ArrowRight } from "lucide-react";
-import { Button } from "@/components/ui/button";
+import { Button } from "@/components/pittaya/ui/button";
 
 export function ButtonWithIcon() {
   return (

--- a/src/components/docs/contents/carousel.tsx
+++ b/src/components/docs/contents/carousel.tsx
@@ -153,8 +153,8 @@ export const carouselDoc: ComponentDoc = {
       title: "Product showcase",
       description:
         "Display featured products with real images, names, prices and call-to-action buttons.",
-      code: `import { Button } from "@/components/ui/button";
-import { Carousel, CarouselItem } from "@/components/ui/carousel";
+      code: `import { Button } from "@/components/pittaya/ui/button";
+import { Carousel, CarouselItem } from "@/components/pittaya/ui/carousel";
 import { ShoppingCart } from "lucide-react";
 import Image from "next/image";
 
@@ -291,7 +291,7 @@ export function ProductCarousel() {
       title: "Customer testimonials",
       description:
         "Showcase customer reviews with real photos and autoplay for social proof.",
-      code: `import { Carousel, CarouselItem } from "@/components/ui/carousel";
+      code: `import { Carousel, CarouselItem } from "@/components/pittaya/ui/carousel";
 import Image from "next/image";
 
 const testimonials = [
@@ -458,8 +458,8 @@ export function TestimonialsCarousel() {
       title: "Promotional banners",
       description:
         "Display marketing campaigns with stunning background images and compelling CTAs.",
-      code: `import { Button } from "@/components/ui/button";
-import { Carousel, CarouselItem } from "@/components/ui/carousel";
+      code: `import { Button } from "@/components/pittaya/ui/button";
+import { Carousel, CarouselItem } from "@/components/pittaya/ui/carousel";
 import { ArrowRight } from "lucide-react";
 import Image from "next/image";
 
@@ -615,7 +615,7 @@ export function PromotionalCarousel() {
       title: "Image gallery",
       description:
         "Showcase portfolio work or project images with clean overlay design.",
-      code: `import { Carousel, CarouselItem } from "@/components/ui/carousel";
+      code: `import { Carousel, CarouselItem } from "@/components/pittaya/ui/carousel";
 import Image from "next/image";
 
 const projects = [

--- a/src/components/docs/contents/copy-button/copy-button.tsx
+++ b/src/components/docs/contents/copy-button/copy-button.tsx
@@ -113,7 +113,7 @@ export const copyButtonDoc: ComponentDoc = {
         "Display multiple options with individual copy buttons and track which one was copied.",
       code: `"use client";
       
-import { CopyButton } from "@/components/ui/copy-button";
+import { CopyButton } from "@/components/pittaya/ui/copy-button";
 import { Badge } from "@/components/ui/badge";
 import { toast } from "sonner";
 import { useState } from "react";
@@ -153,7 +153,7 @@ export function MultipleButtons() {
       title: "API key with security",
       description:
         "Copy sensitive information like API keys with masked display and secure copy.",
-      code: `import { CopyButton } from "@/components/ui/copy-button";
+      code: `import { CopyButton } from "@/components/pittaya/ui/copy-button";
 import { Badge } from "@/components/ui/badge";
 import { KeyIcon } from "lucide-react";
 import { toast } from "sonner";
@@ -198,7 +198,7 @@ export function ApiKeyExample() {
       title: "Share URL",
       description:
         "Enable easy sharing of URLs with visual feedback and contextual information.",
-      code: `import { CopyButton } from "@/components/ui/copy-button";
+      code: `import { CopyButton } from "@/components/pittaya/ui/copy-button";
 import { toast } from "sonner";
 
 export function UrlShare() {

--- a/src/components/docs/contents/installation-section.tsx
+++ b/src/components/docs/contents/installation-section.tsx
@@ -115,7 +115,7 @@ export const installationSectionDoc: ComponentDoc = {
       title: "Basic usage",
       description:
         "Simple usage with just the component slug. Uses all default values.",
-      code: `import { InstallationSection } from "@/components/ui/installation-section";
+      code: `import { InstallationSection } from "@/components/pittaya/ui/installation-section";
 
 export function BasicInstallation() {
   return (
@@ -147,7 +147,7 @@ export function BasicInstallation() {
       id: "custom-text",
       title: "Custom title and description",
       description: "Customize the title and description to match your needs.",
-      code: `import { InstallationSection } from "@/components/ui/installation-section";
+      code: `import { InstallationSection } from "@/components/pittaya/ui/installation-section";
 
 export function CustomInstallation() {
   return (
@@ -182,7 +182,7 @@ export function CustomInstallation() {
       id: "custom-cli",
       title: "Custom CLI command",
       description: "Use a different CLI command or package manager.",
-      code: `import { InstallationSection } from "@/components/ui/installation-section";
+      code: `import { InstallationSection } from "@/components/pittaya/ui/installation-section";
 
 export function CustomCLI() {
   return (

--- a/src/components/docs/contents/orbit-images.tsx
+++ b/src/components/docs/contents/orbit-images.tsx
@@ -138,7 +138,7 @@ export const orbitImagesDoc: ComponentDoc = {
       title: "Basic orbit",
       description:
         "Scroll until the orbit reaches 80% of the viewport to expand the circles and trigger the rotation.",
-      code: `import { OrbitImages } from "@/components/orbit-images";
+      code: `import { OrbitImages } from "@/components/pittaya/ui/orbit-images";
 
 const images = [
   "https://github.com/marcosvbueno.png",


### PR DESCRIPTION
# PR: Examples Import Path Updates

This pull request updates import paths across multiple documentation
files to ensure all UI components reference the new
`@/components/pittaya/ui/` structure.

## What's Updated

### Announcement Badge

Imports updated to:

    @/components/pittaya/ui/announcement-badge

### Button

Imports updated to:

    @/components/pittaya/ui/button

### Carousel

Imports updated to:

    @/components/pittaya/ui/carousel

### Copy Button

Imports updated to:

    @/components/pittaya/ui/copy-button

### Installation Section

Imports updated to:

    @/components/pittaya/ui/installation-section

### Orbit Images

Imports updated to:

    @/components/pittaya/ui/orbit-images

All documentation examples now consistently reflect the updated
component directory structure.
