### PR TITLE
feat: introduces a new showcase section for component documentation

### DIFF
--- a/docs/COMPONENT_DOCS_GUIDE.md
+++ b/docs/COMPONENT_DOCS_GUIDE.md
@@ -186,6 +186,22 @@ export function BasicInput() {
     { id: "examples", title: "Examples", level: 2 }, // 🎯 Examples are auto-expanded in TOC
     { id: "properties", title: "Properties", level: 2 },
   ],
+  showcase: {
+    code: `import { Input } from "@/components/pittaya/ui/input";
+
+export function ShowcaseInput() {
+  return (
+    <div className="space-y-2">
+      <Input type="email" placeholder="Enter your email" />
+    </div>
+  );
+}`,
+    preview: (
+      <div className="space-y-2">
+        <Input type="email" placeholder="Enter your email" />
+      </div>
+    ),
+  },
 });
 ```
 
@@ -240,6 +256,7 @@ export type ComponentDoc = {
   props: DocProp[]; // Component properties
   examples: DocExample[]; // Usage examples
   toc: TocItem[]; // Page table of contents
+  showcase?: DocShowcase; // Optional: Visual preview of the component
 };
 ```
 
@@ -264,6 +281,7 @@ Before finishing, check that you have:
 - [ ] ✅ Tested the page locally
 - [ ] ✅ **Added "Installation" as the first item in the TOC**
 - [ ] ✅ Added "examples" to TOC (individual examples are auto-generated)
+- [ ] ✅ **Added a showcase section**
 - [ ] ✅ Tested the page locally and verified the sidebar navigation
 
 ---

--- a/src/components/docs/contents/tooltip.tsx
+++ b/src/components/docs/contents/tooltip.tsx
@@ -294,4 +294,71 @@ export function CreativeTooltip() {
     { id: "examples", title: "Examples", level: 2 },
     { id: "properties", title: "Properties", level: 2 },
   ],
+  showcase: {
+    code: `import { Button } from "@/components/pittaya/ui/button";
+import { Tooltip, TooltipTrigger, TooltipContentAnimated } from "@/components/pittaya/ui/tooltip";
+
+export function ShowcaseTooltip() {
+  return (
+    <div className="flex flex-wrap gap-4">
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button variant="outline">Hover me</Button>
+        </TooltipTrigger>
+        <TooltipContentAnimated>
+          Smooth animated tooltip
+        </TooltipContentAnimated>
+      </Tooltip>
+      
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button variant="default">Product info</Button>
+        </TooltipTrigger>
+        <TooltipContentAnimated side="right">
+          Positioned at right
+        </TooltipContentAnimated>
+      </Tooltip>
+      
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button variant="secondary">Check status</Button>
+        </TooltipTrigger>
+        <TooltipContentAnimated side="bottom">
+          ✅ All systems operational
+        </TooltipContentAnimated>
+      </Tooltip>
+    </div>
+  );
+}`,
+    preview: (
+      <div className="flex flex-wrap gap-4">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button variant="outline">Hover me</Button>
+          </TooltipTrigger>
+          <TooltipContentAnimated>
+            Smooth animated tooltip
+          </TooltipContentAnimated>
+        </Tooltip>
+
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button variant="default">Product info</Button>
+          </TooltipTrigger>
+          <TooltipContentAnimated side="right">
+            Positioned at right
+          </TooltipContentAnimated>
+        </Tooltip>
+
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button variant="secondary">Check status</Button>
+          </TooltipTrigger>
+          <TooltipContentAnimated side="bottom">
+            ✅ All systems operational
+          </TooltipContentAnimated>
+        </Tooltip>
+      </div>
+    ),
+  },
 });


### PR DESCRIPTION
This pull request introduces a new **showcase** section for component documentation, allowing each component documentation page to include a visual preview alongside an example code snippet. The changes update both the documentation guide and an existing component doc to demonstrate how this new feature should be used.

---

## 🧩 Component Documentation Enhancements

- Added an optional `showcase` field to the `ComponentDoc` type, enabling components to display a visual preview together with the corresponding code snippet directly in their documentation.

- Updated the documentation guide (`COMPONENT_DOCS_GUIDE.md`) to explain how to add a `showcase` section, including a new checklist item to ensure it is properly included when documenting components.

- Added a practical `showcase` example to the `CreativeTooltip` component documentation, demonstrating how to present multiple tooltip variants with both live previews and example code.
