### PR TITLE
feat: add select component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-popover": "^1.1.15",
         "@radix-ui/react-radio-group": "^1.3.8",
+        "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-separator": "^1.1.7",
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-tabs": "^1.1.13",
@@ -1443,6 +1444,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@radix-ui/number": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
+      "integrity": "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==",
+      "license": "MIT"
+    },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
@@ -1944,6 +1951,49 @@
         "@radix-ui/react-primitive": "2.1.3",
         "@radix-ui/react-use-callback-ref": "1.1.1",
         "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.2.6.tgz",
+      "integrity": "sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-radio-group": "^1.3.8",
+    "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tabs": "^1.1.13",

--- a/src/components/docs/contents/select/select-examples.tsx
+++ b/src/components/docs/contents/select/select-examples.tsx
@@ -1,0 +1,349 @@
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { DocExample } from "@/lib/docs/types";
+
+export const selectExamples: DocExample[] = [
+  {
+    id: "basic",
+    title: "Basic usage",
+    description:
+      "A simple select for choosing a programming language with a placeholder.",
+    code: `import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/pittaya/ui/select";
+
+export function BasicSelect() {
+  return (
+    <Select>
+      <SelectTrigger className="w-[280px]">
+        <SelectValue placeholder="Select a language" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="javascript">JavaScript</SelectItem>
+        <SelectItem value="typescript">TypeScript</SelectItem>
+        <SelectItem value="python">Python</SelectItem>
+        <SelectItem value="rust">Rust</SelectItem>
+        <SelectItem value="go">Go</SelectItem>
+      </SelectContent>
+    </Select>
+  );
+}`,
+    preview: (
+      <Select>
+        <SelectTrigger className="w-[280px]">
+          <SelectValue placeholder="Select a language" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="javascript">JavaScript</SelectItem>
+          <SelectItem value="typescript">TypeScript</SelectItem>
+          <SelectItem value="python">Python</SelectItem>
+          <SelectItem value="rust">Rust</SelectItem>
+          <SelectItem value="go">Go</SelectItem>
+        </SelectContent>
+      </Select>
+    ),
+  },
+  {
+    id: "with-label",
+    title: "With label",
+    description:
+      "Select paired with a label for better accessibility and form structure.",
+    code: `import { Label } from "@/components/pittaya/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/pittaya/ui/select";
+
+export function SelectWithLabel() {
+  return (
+    <div className="grid w-full max-w-sm items-center gap-2">
+      <Label htmlFor="framework">Framework</Label>
+      <Select>
+        <SelectTrigger id="framework">
+          <SelectValue placeholder="Choose your framework" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="react">React</SelectItem>
+          <SelectItem value="vue">Vue</SelectItem>
+          <SelectItem value="angular">Angular</SelectItem>
+          <SelectItem value="svelte">Svelte</SelectItem>
+          <SelectItem value="solid">SolidJS</SelectItem>
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}`,
+    preview: (
+      <div className="grid w-full max-w-sm items-center gap-2">
+        <Label htmlFor="framework">Framework</Label>
+        <Select>
+          <SelectTrigger id="framework">
+            <SelectValue placeholder="Choose your framework" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="react">React</SelectItem>
+            <SelectItem value="vue">Vue</SelectItem>
+            <SelectItem value="angular">Angular</SelectItem>
+            <SelectItem value="svelte">Svelte</SelectItem>
+            <SelectItem value="solid">SolidJS</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+    ),
+  },
+  {
+    id: "grouped",
+    title: "Grouped options",
+    description:
+      "Organize related options into groups with labels for better navigation in larger lists.",
+    code: `import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/pittaya/ui/select";
+
+export function GroupedSelect() {
+  return (
+    <Select>
+      <SelectTrigger className="w-[280px]">
+        <SelectValue placeholder="Select a database" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectGroup>
+          <SelectLabel>SQL Databases</SelectLabel>
+          <SelectItem value="postgresql">PostgreSQL</SelectItem>
+          <SelectItem value="mysql">MySQL</SelectItem>
+          <SelectItem value="sqlite">SQLite</SelectItem>
+        </SelectGroup>
+        <SelectGroup>
+          <SelectLabel>NoSQL Databases</SelectLabel>
+          <SelectItem value="mongodb">MongoDB</SelectItem>
+          <SelectItem value="redis">Redis</SelectItem>
+          <SelectItem value="dynamodb">DynamoDB</SelectItem>
+        </SelectGroup>
+      </SelectContent>
+    </Select>
+  );
+}`,
+    preview: (
+      <Select>
+        <SelectTrigger className="w-[280px]">
+          <SelectValue placeholder="Select a database" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectGroup>
+            <SelectLabel>SQL Databases</SelectLabel>
+            <SelectItem value="postgresql">PostgreSQL</SelectItem>
+            <SelectItem value="mysql">MySQL</SelectItem>
+            <SelectItem value="sqlite">SQLite</SelectItem>
+          </SelectGroup>
+          <SelectGroup>
+            <SelectLabel>NoSQL Databases</SelectLabel>
+            <SelectItem value="mongodb">MongoDB</SelectItem>
+            <SelectItem value="redis">Redis</SelectItem>
+            <SelectItem value="dynamodb">DynamoDB</SelectItem>
+          </SelectGroup>
+        </SelectContent>
+      </Select>
+    ),
+  },
+  {
+    id: "with-separator",
+    title: "With separator",
+    description:
+      "Use separators to visually divide different sections of options without explicit grouping.",
+    code: `import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/pittaya/ui/select";
+
+export function SelectWithSeparator() {
+  return (
+    <Select>
+      <SelectTrigger className="w-[280px]">
+        <SelectValue placeholder="Select a cloud provider" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="aws">AWS (Amazon)</SelectItem>
+        <SelectItem value="azure">Azure (Microsoft)</SelectItem>
+        <SelectItem value="gcp">GCP (Google)</SelectItem>
+        <SelectSeparator />
+        <SelectItem value="digitalocean">DigitalOcean</SelectItem>
+        <SelectItem value="vercel">Vercel</SelectItem>
+        <SelectItem value="netlify">Netlify</SelectItem>
+      </SelectContent>
+    </Select>
+  );
+}`,
+    preview: (
+      <Select>
+        <SelectTrigger className="w-[280px]">
+          <SelectValue placeholder="Select a cloud provider" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="aws">AWS (Amazon)</SelectItem>
+          <SelectItem value="azure">Azure (Microsoft)</SelectItem>
+          <SelectItem value="gcp">GCP (Google)</SelectItem>
+          <SelectSeparator />
+          <SelectItem value="digitalocean">DigitalOcean</SelectItem>
+          <SelectItem value="vercel">Vercel</SelectItem>
+          <SelectItem value="netlify">Netlify</SelectItem>
+        </SelectContent>
+      </Select>
+    ),
+  },
+  {
+    id: "disabled",
+    title: "Disabled state",
+    description:
+      "Prevent user interaction with the select using the disabled prop.",
+    code: `import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/pittaya/ui/select";
+
+export function DisabledSelect() {
+  return (
+    <Select disabled>
+      <SelectTrigger className="w-[280px]">
+        <SelectValue placeholder="Select a runtime" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="nodejs">Node.js</SelectItem>
+        <SelectItem value="deno">Deno</SelectItem>
+        <SelectItem value="bun">Bun</SelectItem>
+      </SelectContent>
+    </Select>
+  );
+}`,
+    preview: (
+      <Select disabled>
+        <SelectTrigger className="w-[280px]">
+          <SelectValue placeholder="Select a runtime" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="nodejs">Node.js</SelectItem>
+          <SelectItem value="deno">Deno</SelectItem>
+          <SelectItem value="bun">Bun</SelectItem>
+        </SelectContent>
+      </Select>
+    ),
+  },
+  {
+    id: "disabled-items",
+    title: "Disabled items",
+    description:
+      "Disable specific options within the select while keeping others interactive.",
+    code: `import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/pittaya/ui/select";
+
+export function SelectWithDisabledItems() {
+  return (
+    <Select>
+      <SelectTrigger className="w-[280px]">
+        <SelectValue placeholder="Select a version" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="v1">Version 1.0 (Legacy)</SelectItem>
+        <SelectItem value="v2" disabled>
+          Version 2.0 (Deprecated)
+        </SelectItem>
+        <SelectItem value="v3">Version 3.0 (Stable)</SelectItem>
+        <SelectItem value="v4">Version 4.0 (Latest)</SelectItem>
+      </SelectContent>
+    </Select>
+  );
+}`,
+    preview: (
+      <Select>
+        <SelectTrigger className="w-[280px]">
+          <SelectValue placeholder="Select a version" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="v1">Version 1.0 (Legacy)</SelectItem>
+          <SelectItem value="v2" disabled>
+            Version 2.0 (Deprecated)
+          </SelectItem>
+          <SelectItem value="v3">Version 3.0 (Stable)</SelectItem>
+          <SelectItem value="v4">Version 4.0 (Latest)</SelectItem>
+        </SelectContent>
+      </Select>
+    ),
+  },
+  {
+    id: "default-value",
+    title: "With default value",
+    description:
+      "Pre-select an option by providing a defaultValue for uncontrolled components.",
+    code: `import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/pittaya/ui/select";
+
+export function SelectWithDefault() {
+  return (
+    <Select defaultValue="vscode">
+      <SelectTrigger className="w-[280px]">
+        <SelectValue placeholder="Select an editor" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="vscode">VS Code</SelectItem>
+        <SelectItem value="webstorm">WebStorm</SelectItem>
+        <SelectItem value="vim">Vim</SelectItem>
+        <SelectItem value="neovim">Neovim</SelectItem>
+        <SelectItem value="sublime">Sublime Text</SelectItem>
+      </SelectContent>
+    </Select>
+  );
+}`,
+    preview: (
+      <Select defaultValue="vscode">
+        <SelectTrigger className="w-[280px]">
+          <SelectValue placeholder="Select an editor" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="vscode">VS Code</SelectItem>
+          <SelectItem value="webstorm">WebStorm</SelectItem>
+          <SelectItem value="vim">Vim</SelectItem>
+          <SelectItem value="neovim">Neovim</SelectItem>
+          <SelectItem value="sublime">Sublime Text</SelectItem>
+        </SelectContent>
+      </Select>
+    ),
+  },
+];

--- a/src/components/docs/contents/select/select.tsx
+++ b/src/components/docs/contents/select/select.tsx
@@ -1,0 +1,198 @@
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { createComponentDoc } from "@/helpers/component-doc";
+import type { ComponentDoc } from "@/lib/docs/types";
+
+import { selectExamples } from "./select-examples";
+
+export const selectDoc: ComponentDoc = createComponentDoc({
+  slug: "select",
+  metadata: {
+    name: "Select",
+    description:
+      "An accessible dropdown select component for choosing a single option from a list of choices.",
+    category: "Forms",
+    status: "stable",
+  },
+  sections: [
+    {
+      id: "when-to-use",
+      title: "When to use",
+      level: 2,
+      content: (
+        <div className="space-y-4 text-base leading-relaxed text-muted-foreground">
+          <p>
+            Use Select when you need users to choose a single option from a
+            predefined list of 5 or more items. For shorter lists (2-4 options),
+            consider using Radio Buttons instead for better visibility and
+            accessibility.
+          </p>
+          <p>
+            Select components are ideal for forms where space is limited but you
+            need to present multiple options. They work well for settings, filters,
+            configuration panels, and data entry forms.
+          </p>
+        </div>
+      ),
+    },
+    {
+      id: "best-practices",
+      title: "Best practices",
+      level: 2,
+      content: (
+        <div className="space-y-4 text-base leading-relaxed text-muted-foreground">
+          <ul className="list-disc space-y-2 pl-5">
+            <li>
+              Always provide a clear placeholder or default value that describes
+              what the user should select.
+            </li>
+            <li>
+              Keep option labels concise and descriptive—avoid overly long text
+              that might be truncated.
+            </li>
+            <li>
+              Sort options in a logical order: alphabetically, numerically, or by
+              frequency of use.
+            </li>
+            <li>
+              Use <code>SelectGroup</code> and <code>SelectLabel</code> to
+              organize related options into categories for better scanability.
+            </li>
+            <li>
+              Provide visual feedback for disabled states and ensure proper error
+              messaging when validation fails.
+            </li>
+            <li>
+              For searchable or very long lists, consider using a Combobox or
+              Multi-Select component instead.
+            </li>
+          </ul>
+        </div>
+      ),
+    },
+    {
+      id: "accessibility",
+      title: "Accessibility",
+      level: 2,
+      content: (
+        <div className="space-y-4 text-base leading-relaxed text-muted-foreground">
+          <p>
+            The Select component is built on Radix UI primitives and follows WAI-ARIA
+            design patterns for accessible dropdown menus. It includes:
+          </p>
+          <ul className="list-disc space-y-2 pl-5">
+            <li>
+              Full keyboard navigation support (Arrow keys, Enter, Escape, Home,
+              End)
+            </li>
+            <li>
+              Proper ARIA attributes for screen readers (<code>aria-expanded</code>,{" "}
+              <code>aria-haspopup</code>, <code>role="combobox"</code>)
+            </li>
+            <li>
+              Focus management that traps focus within the dropdown when open
+            </li>
+            <li>
+              Type-ahead functionality for quick option selection
+            </li>
+          </ul>
+          <p>
+            Always pair Select with a visible <code>Label</code> component for
+            clarity, even if using placeholder text.
+          </p>
+        </div>
+      ),
+    },
+  ],
+  props: [
+    {
+      name: "defaultValue",
+      type: "string",
+      description:
+        "The value of the select when initially rendered. Useful for uncontrolled components.",
+    },
+    {
+      name: "value",
+      type: "string",
+      description:
+        "The controlled value of the select. Must be used with onValueChange for controlled components.",
+    },
+    {
+      name: "onValueChange",
+      type: "(value: string) => void",
+      description:
+        "Event handler called when the selected value changes.",
+    },
+    {
+      name: "disabled",
+      type: "boolean",
+      defaultValue: "false",
+      description: "When true, prevents the user from interacting with the select.",
+    },
+    {
+      name: "name",
+      type: "string",
+      description:
+        "The name of the select. Submitted with its owning form as part of a name/value pair.",
+    },
+    {
+      name: "required",
+      type: "boolean",
+      defaultValue: "false",
+      description:
+        "When true, indicates that the user must select a value before the owning form can be submitted.",
+    },
+  ],
+  examples: selectExamples,
+  toc: [
+    { id: "installation", title: "Installation", level: 2 },
+    { id: "when-to-use", title: "When to use", level: 2 },
+    { id: "best-practices", title: "Best practices", level: 2 },
+    { id: "accessibility", title: "Accessibility", level: 2 },
+    { id: "examples", title: "Examples", level: 2 },
+    { id: "properties", title: "Properties", level: 2 },
+  ],
+  showcase: {
+    preview: (
+      <Select defaultValue="react">
+        <SelectTrigger className="w-[200px]">
+          <SelectValue placeholder="Select a framework" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="react">React</SelectItem>
+          <SelectItem value="vue">Vue</SelectItem>
+          <SelectItem value="angular">Angular</SelectItem>
+          <SelectItem value="svelte">Svelte</SelectItem>
+        </SelectContent>
+      </Select>
+    ),
+    code: `import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/pittaya/ui/select";
+
+export function SelectExample() {
+  return (
+    <Select defaultValue="react">
+      <SelectTrigger className="w-[200px]">
+        <SelectValue placeholder="Select a framework" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="react">React</SelectItem>
+        <SelectItem value="vue">Vue</SelectItem>
+        <SelectItem value="angular">Angular</SelectItem>
+        <SelectItem value="svelte">Svelte</SelectItem>
+      </SelectContent>
+    </Select>
+  );
+}`,
+  },
+});

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -17,7 +17,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm shadow-xs ring-offset-background placeholder:text-muted-foreground hover:bg-accent hover:text-accent-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-input dark:bg-input/30 dark:hover:bg-input/50 [&>span]:line-clamp-1",
       className
     )}
     {...props}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,0 +1,158 @@
+import * as SelectPrimitive from "@radix-ui/react-select";
+import { Check, ChevronDown, ChevronUp } from "lucide-react";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Select = SelectPrimitive.Root;
+
+const SelectGroup = SelectPrimitive.Group;
+
+const SelectValue = SelectPrimitive.Value;
+
+const SelectTrigger = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      className
+    )}
+    {...props}
+  >
+    {children}
+    <SelectPrimitive.Icon asChild>
+      <ChevronDown className="h-4 w-4 opacity-50" />
+    </SelectPrimitive.Icon>
+  </SelectPrimitive.Trigger>
+));
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
+
+const SelectScrollUpButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollUpButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollUpButton
+    ref={ref}
+    className={cn(
+      "flex cursor-default items-center justify-center py-1",
+      className
+    )}
+    {...props}
+  >
+    <ChevronUp className="h-4 w-4" />
+  </SelectPrimitive.ScrollUpButton>
+));
+SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName;
+
+const SelectScrollDownButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollDownButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollDownButton
+    ref={ref}
+    className={cn(
+      "flex cursor-default items-center justify-center py-1",
+      className
+    )}
+    {...props}
+  >
+    <ChevronDown className="h-4 w-4" />
+  </SelectPrimitive.ScrollDownButton>
+));
+SelectScrollDownButton.displayName =
+  SelectPrimitive.ScrollDownButton.displayName;
+
+const SelectContent = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
+>(({ className, children, position = "popper", ...props }, ref) => (
+  <SelectPrimitive.Portal>
+    <SelectPrimitive.Content
+      ref={ref}
+      className={cn(
+        "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        position === "popper" &&
+          "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+        className
+      )}
+      position={position}
+      {...props}
+    >
+      <SelectScrollUpButton />
+      <SelectPrimitive.Viewport
+        className={cn(
+          "p-1",
+          position === "popper" &&
+            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]"
+        )}
+      >
+        {children}
+      </SelectPrimitive.Viewport>
+      <SelectScrollDownButton />
+    </SelectPrimitive.Content>
+  </SelectPrimitive.Portal>
+));
+SelectContent.displayName = SelectPrimitive.Content.displayName;
+
+const SelectLabel = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Label
+    ref={ref}
+    className={cn("py-1.5 pl-2 pr-2 text-sm font-semibold", className)}
+    {...props}
+  />
+));
+SelectLabel.displayName = SelectPrimitive.Label.displayName;
+
+const SelectItem = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <SelectPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </SelectPrimitive.ItemIndicator>
+    </span>
+
+    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+  </SelectPrimitive.Item>
+));
+SelectItem.displayName = SelectPrimitive.Item.displayName;
+
+const SelectSeparator = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    {...props}
+  />
+));
+SelectSeparator.displayName = SelectPrimitive.Separator.displayName;
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+};

--- a/src/lib/docs/component-details.tsx
+++ b/src/lib/docs/component-details.tsx
@@ -13,6 +13,7 @@ import { multiSelectDoc } from "@/components/docs/contents/multi-select/multi-se
 import { orbitImagesDoc } from "@/components/docs/contents/orbit-images";
 import { popoverDoc } from "@/components/docs/contents/popover";
 import { radioGroupDoc } from "@/components/docs/contents/radio-group/radio-group";
+import { selectDoc } from "@/components/docs/contents/select/select";
 import { skeletonDoc } from "@/components/docs/contents/skeleton/skeleton";
 import { tabsDoc } from "@/components/docs/contents/tabs";
 import { textareaDoc } from "@/components/docs/contents/textarea/textarea";
@@ -36,6 +37,7 @@ const docs: Record<string, ComponentDoc> = {
   [orbitImagesDoc.slug]: orbitImagesDoc,
   [popoverDoc.slug]: popoverDoc,
   [radioGroupDoc.slug]: radioGroupDoc,
+  [selectDoc.slug]: selectDoc,
   [skeletonDoc.slug]: skeletonDoc,
   [tabsDoc.slug]: tabsDoc,
   [textareaDoc.slug]: textareaDoc,

--- a/src/lib/docs/components-index.ts
+++ b/src/lib/docs/components-index.ts
@@ -151,6 +151,16 @@ export const componentsIndex: ComponentIndexItem[] = [
     dependencies: ["@radix-ui/react-radio-group", "class-variance-authority"],
   },
   {
+    slug: "select",
+    name: "Select",
+    description:
+      "An accessible dropdown select component for choosing a single option from a list of choices.",
+    category: "Forms",
+    status: "stable",
+    tags: ["select", "dropdown", "form", "input", "picker"],
+    dependencies: ["@radix-ui/react-select", "lucide-react"],
+  },
+  {
     slug: "skeleton",
     name: "Skeleton",
     description:


### PR DESCRIPTION
This pull request introduces a new **Select** component to the UI library, including its full implementation, documentation, and integration into the documentation system. The update adds a fully accessible dropdown select built with Radix UI, along with comprehensive usage examples and proper registration in the docs index.

---

## 🧱 New Select Component Implementation & Documentation

- Added a new `Select` component and its subcomponents (such as `SelectTrigger`, `SelectContent`, `SelectItem`, etc.) in `src/components/ui/select.tsx`.  
  The implementation is based on Radix UI primitives and Lucide icons, with custom styling and accessibility best practices.

- Created detailed documentation for the Select component in `src/components/docs/contents/select/select.tsx`, including usage guidelines, best practices, accessibility notes, API props, and a showcase example.

- Added a comprehensive set of usage examples in `src/components/docs/contents/select/select-examples.tsx`, covering:
  - Basic usage  
  - Labeled selects  
  - Grouped options and separators  
  - Disabled states and disabled items  
  - Default values  

---

## 📚 Integration with the Documentation System

- Registered the Select component documentation in the documentation details and components index:
  - `src/lib/docs/component-details.tsx`
  - `src/lib/docs/components-index.ts`

  This makes the component discoverable, searchable, and properly rendered within the documentation site.

---

## 📦 Dependency Updates

- Added `@radix-ui/react-select` as a new dependency in `package.json` to support the Select component implementation.
