### PR TITLE
feat: add `Progress` component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-popover": "^1.1.15",
+        "@radix-ui/react-progress": "^1.1.8",
         "@radix-ui/react-radio-group": "^1.3.8",
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-separator": "^1.1.7",
@@ -112,7 +113,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1906,6 +1906,86 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-progress": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.1.8.tgz",
+      "integrity": "sha512-+gISHcSPUJ7ktBy9RnTqbdKW78bcGke3t6taawyZ71pio1JewwGSJizycs7rLhGTvMJYCQB1DBK4KQsxs7U8dA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-context": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-progress/node_modules/@radix-ui/react-context": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.3.tgz",
+      "integrity": "sha512-ieIFACdMpYfMEjF0rEf5KLvfVyIkOz6PDGyNnP+u+4xQ6jny3VCgA4OgXOwNx2aUkxn8zx9fiVcM8CfFYv9Lxw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-progress/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.4.tgz",
+      "integrity": "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-progress/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
+      "integrity": "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-radio-group": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.3.8.tgz",
@@ -2374,7 +2454,6 @@
       "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.4.0.tgz",
       "integrity": "sha512-k4iu1R6e5D54918V4sqmISUkI5OgTw3v7/sDRKEC632Wd5g2WBtUS5gyG63X0GJO/HZUj1tsjSXfyzwrUHZl1g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.17.8",
         "@types/react-reconciler": "^0.32.0",
@@ -2824,7 +2903,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.10.tgz",
       "integrity": "sha512-EhBeSYX0Y6ye8pNebpKrwFJq7BoQ8J5SO6NlvNwwHjSj6adXJViPQrKlsyPw7hLBLvckEMO1yxeGdR82YBBlDg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -2835,7 +2913,6 @@
       "integrity": "sha512-i5ZzwYpqjmrKenzkoLM2Ibzt6mAsM7pxB6BCIouEVVmgiqaMj1TjaK7hnA36hbW5aZv20kx7Lw6hWzPWg0Rurw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -2870,7 +2947,6 @@
       "resolved": "https://registry.npmjs.org/@types/three/-/three-0.181.0.tgz",
       "integrity": "sha512-MLF1ks8yRM2k71D7RprFpDb9DOX0p22DbdPqT/uAkc6AtQXjxWCVDjCy23G9t1o8HcQPk7woD2NIyiaWcWPYmA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dimforge/rapier3d-compat": "~0.12.0",
         "@tweenjs/tween.js": "~23.1.3",
@@ -2938,7 +3014,6 @@
       "integrity": "sha512-6/cmF2piao+f6wSxUsJLZjck7OQsYyRtcOZS02k7XINSNlz93v6emM8WutDQSXnroG2xwYlEVHJI+cPA7CPM3Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.50.0",
         "@typescript-eslint/types": "8.50.0",
@@ -3522,7 +3597,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3918,7 +3992,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4446,8 +4519,7 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/embla-carousel-autoplay": {
       "version": "8.6.0",
@@ -4707,7 +4779,6 @@
       "integrity": "sha512-TS9bTNIryDzStCpJN93aC5VRSW3uTx9sClUn4B87pwiCaJh220otoI0X8mJKr+VcPtniMdN8GKjlwgWGUv5ZKA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4894,7 +4965,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6994,7 +7064,6 @@
       "resolved": "https://registry.npmjs.org/next/-/next-16.0.10.tgz",
       "integrity": "sha512-RtWh5PUgI+vxlV3HdR+IfWA1UUHu0+Ram/JBO4vWB54cVPentCD0e+lxyAYEsDTqGGMg7qpjhKh6dc6aW7W/sA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@next/env": "16.0.10",
         "@swc/helpers": "0.5.15",
@@ -7425,7 +7494,6 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -7603,7 +7671,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7613,7 +7680,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -7626,7 +7692,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.69.0.tgz",
       "integrity": "sha512-yt6ZGME9f4F6WHwevrvpAjh42HMvocuSnSIHUGycBqXIJdhqGSPQzTpGF+1NLREk/58IdPxEMfPcFCjlMhclGw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -8527,8 +8592,7 @@
       "version": "0.181.1",
       "resolved": "https://registry.npmjs.org/three/-/three-0.181.1.tgz",
       "integrity": "sha512-bz9xZUQMw3pJbjKy7roiwXWgAp+oVUa+4k5o0oBAQ+IFJuru1xzvtk63h6k72XZanXS/SgoEhV6927Vgazyq2w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/three-mesh-bvh": {
       "version": "0.8.3",
@@ -8603,7 +8667,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8839,7 +8902,6 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9264,7 +9326,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.2.1.tgz",
       "integrity": "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-popover": "^1.1.15",
+    "@radix-ui/react-progress": "^1.1.8",
     "@radix-ui/react-radio-group": "^1.3.8",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-separator": "^1.1.7",

--- a/src/components/docs/contents/progress/progress-examples.tsx
+++ b/src/components/docs/contents/progress/progress-examples.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Progress } from "@/components/ui/progress";
+
+export function BasicProgressPreview() {
+  return (
+    <div className="w-full max-w-55 space-y-2">
+      <div className="flex justify-between text-sm">
+        <span className="text-muted-foreground">Progress</span>
+        <span className="font-medium">65%</span>
+      </div>
+      <Progress value={65} />
+    </div>
+  );
+}
+
+export function FileUploadProgressPreview() {
+  const [progress, setProgress] = useState(0);
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setProgress((prev) => {
+        if (prev >= 100) {
+          clearInterval(timer);
+          return 100;
+        }
+        return prev + 1;
+      });
+    }, 50);
+
+    return () => clearInterval(timer);
+  }, []);
+
+  return (
+    <div className="w-full max-w-55 space-y-2">
+      <div className="flex justify-between gap-4 text-sm">
+        <span className="text-muted-foreground">Uploading document.pdf</span>
+        <span className="font-medium">{progress}%</span>
+      </div>
+      <Progress value={progress} />
+      {progress === 100 && (
+        <p className="text-sm text-green-600">Upload complete!</p>
+      )}
+    </div>
+  );
+}
+
+export function ProgressVariantsPreview() {
+  return (
+    <div className="w-full max-w-55 space-y-6">
+      <div className="space-y-2">
+        <div className="flex justify-between text-sm">
+          <span className="text-muted-foreground">Default progress</span>
+          <span className="font-medium">75%</span>
+        </div>
+        <Progress value={75} variant="default" />
+      </div>
+
+      <div className="space-y-2">
+        <div className="flex justify-between text-sm">
+          <span className="text-muted-foreground">Success progress</span>
+          <span className="font-medium">100%</span>
+        </div>
+        <Progress value={100} variant="success" />
+      </div>
+
+      <div className="space-y-2">
+        <div className="flex justify-between text-sm">
+          <span className="text-muted-foreground">Secondary progress</span>
+          <span className="font-medium">50%</span>
+        </div>
+        <Progress value={50} variant="secondary" />
+      </div>
+
+      <div className="space-y-2">
+        <div className="flex justify-between text-sm">
+          <span className="text-muted-foreground">Destructive progress</span>
+          <span className="font-medium">30%</span>
+        </div>
+        <Progress value={30} variant="destructive" />
+      </div>
+    </div>
+  );
+}
+
+export function MultiStepProgressPreview() {
+  const [currentStep, setCurrentStep] = useState(1);
+  const totalSteps = 4;
+  const progress = (currentStep / totalSteps) * 100;
+
+  return (
+    <div className="w-full max-w-55 space-y-4">
+      <div className="space-y-2">
+        <div className="flex justify-between text-sm">
+          <span className="text-muted-foreground">
+            Step {currentStep} of {totalSteps}
+          </span>
+          <span className="font-medium">{Math.round(progress)}%</span>
+        </div>
+        <Progress value={progress} />
+      </div>
+
+      <div className="flex gap-2">
+        <Button
+          variant={"secondary"}
+          onClick={() => setCurrentStep(Math.max(1, currentStep - 1))}
+          disabled={currentStep === 1}
+        >
+          Previous
+        </Button>
+        <Button
+          onClick={() => setCurrentStep(Math.min(totalSteps, currentStep + 1))}
+          disabled={currentStep === totalSteps}
+        >
+          {currentStep === totalSteps ? "Complete" : "Next"}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/docs/contents/progress/progress.tsx
+++ b/src/components/docs/contents/progress/progress.tsx
@@ -1,0 +1,317 @@
+import { createComponentDoc } from "@/helpers/component-doc";
+import type { ComponentDoc } from "@/lib/docs/types";
+
+import {
+  BasicProgressPreview,
+  FileUploadProgressPreview,
+  MultiStepProgressPreview,
+  ProgressVariantsPreview,
+} from "./progress-examples";
+
+export const progressDoc: ComponentDoc = createComponentDoc({
+  slug: "progress",
+  metadata: {
+    name: "Progress",
+    description:
+      "An accessible progress indicator that displays the completion status of a task or operation.",
+    category: "Feedback",
+    status: "stable",
+  },
+  sections: [
+    {
+      id: "when-to-use",
+      title: "When to use",
+      level: 2,
+      content: (
+        <div className="text-muted-foreground space-y-4 text-base leading-relaxed">
+          <p>
+            Use Progress when you need to display the completion status of a
+            task, such as file uploads, form completion, multi-step processes,
+            or any operation with a measurable progress percentage.
+          </p>
+          <p>
+            The component is ideal for providing visual feedback to users about
+            ongoing operations, helping them understand how much of a task has
+            been completed and how much remains.
+          </p>
+        </div>
+      ),
+    },
+    {
+      id: "best-practices",
+      title: "Best practices",
+      level: 2,
+      content: (
+        <div className="text-muted-foreground space-y-4 text-base leading-relaxed">
+          <ul className="list-disc space-y-2 pl-5">
+            <li>
+              Always provide a label or description to indicate what progress is
+              being tracked.
+            </li>
+            <li>
+              Use the appropriate variant to communicate the nature of the
+              operation (default for standard tasks, success for completed
+              operations, destructive for critical tasks).
+            </li>
+            <li>
+              Display the percentage value alongside the progress bar for better
+              clarity when possible.
+            </li>
+          </ul>
+        </div>
+      ),
+    },
+    {
+      id: "accessibility",
+      title: "Accessibility",
+      level: 2,
+      content: (
+        <div className="text-muted-foreground space-y-4 text-base leading-relaxed">
+          <p>
+            The Progress component uses Radix UI&apos;s{" "}
+            <code>@radix-ui/react-progress</code> primitive, which provides
+            proper ARIA attributes including{" "}
+            <code>role=&quot;progressbar&quot;</code>,{" "}
+            <code>aria-valuemin</code>, <code>aria-valuemax</code>, and{" "}
+            <code>aria-valuenow</code> to ensure screen readers can accurately
+            announce the progress status.
+          </p>
+          <p>
+            When implementing, consider adding <code>aria-label</code> or{" "}
+            <code>aria-labelledby</code> to provide context about what is
+            progressing, especially in cases where multiple progress indicators
+            are visible simultaneously.
+          </p>
+        </div>
+      ),
+    },
+  ],
+  props: [
+    {
+      name: "value",
+      type: "number",
+      defaultValue: "0",
+      description:
+        "The current progress value (0-100). Controls the fill percentage of the progress bar.",
+    },
+    {
+      name: "variant",
+      type: '"default" | "secondary" | "destructive" | "success"',
+      defaultValue: '"default"',
+      description:
+        "Defines the visual style of the progress bar. Use 'default' for standard operations, 'success' for completed tasks, 'destructive' for critical operations, or 'secondary' for secondary operations.",
+    },
+    {
+      name: "max",
+      type: "number",
+      defaultValue: "100",
+      description:
+        "The maximum progress value. Defaults to 100 for percentage-based progress.",
+    },
+    {
+      name: "className",
+      type: "string",
+      description:
+        "Additional CSS classes to apply to the progress root element.",
+    },
+  ],
+  examples: [
+    {
+      id: "basic",
+      title: "Basic usage",
+      description: "A simple progress bar showing 65% completion.",
+      code: `import { Progress } from "@/components/pittaya/ui/progress";
+
+export function BasicProgress() {
+  return (
+    <div className="space-y-2">
+      <div className="flex justify-between text-sm">
+        <span className="text-muted-foreground">Progress</span>
+        <span className="font-medium">65%</span>
+      </div>
+      <Progress value={65} />
+    </div>
+  );
+}`,
+      preview: <BasicProgressPreview />,
+    },
+    {
+      id: "file-upload",
+      title: "File upload simulation",
+      description:
+        "An animated progress bar simulating a file upload operation with automatic progression.",
+      code: `import { Progress } from "@/components/pittaya/ui/progress";
+import { useEffect, useState } from "react";
+
+export function FileUploadProgress() {
+  const [progress, setProgress] = useState(0);
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setProgress((prev) => {
+        if (prev >= 100) {
+          clearInterval(timer);
+          return 100;
+        }
+        return prev + 1;
+      });
+    }, 50);
+
+    return () => clearInterval(timer);
+  }, []);
+
+  return (
+    <div className="space-y-2">
+      <div className="flex justify-between text-sm">
+        <span className="text-muted-foreground">Uploading document.pdf</span>
+        <span className="font-medium">{progress}%</span>
+      </div>
+      <Progress value={progress} />
+      {progress === 100 && (
+        <p className="text-sm text-green-600">Upload complete!</p>
+      )}
+    </div>
+  );
+}`,
+      preview: <FileUploadProgressPreview />,
+    },
+    {
+      id: "variants",
+      title: "Progress variants",
+      description:
+        "Different visual styles for various use cases and contexts.",
+      code: `import { Progress } from "@/components/pittaya/ui/progress";
+
+export function ProgressVariants() {
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <div className="flex justify-between text-sm">
+          <span className="text-muted-foreground">Default progress</span>
+          <span className="font-medium">75%</span>
+        </div>
+        <Progress value={75} variant="default" />
+      </div>
+
+      <div className="space-y-2">
+        <div className="flex justify-between text-sm">
+          <span className="text-muted-foreground">Success progress</span>
+          <span className="font-medium">100%</span>
+        </div>
+        <Progress value={100} variant="success" />
+      </div>
+
+      <div className="space-y-2">
+        <div className="flex justify-between text-sm">
+          <span className="text-muted-foreground">Secondary progress</span>
+          <span className="font-medium">50%</span>
+        </div>
+        <Progress value={50} variant="secondary" />
+      </div>
+
+      <div className="space-y-2">
+        <div className="flex justify-between text-sm">
+          <span className="text-muted-foreground">Destructive progress</span>
+          <span className="font-medium">30%</span>
+        </div>
+        <Progress value={30} variant="destructive" />
+      </div>
+    </div>
+  );
+}`,
+      preview: <ProgressVariantsPreview />,
+    },
+    {
+      id: "multi-step",
+      title: "Multi-step form progress",
+      description:
+        "Progress indicator for a multi-step form showing current completion status.",
+      code: `import { Progress } from "@/components/pittaya/ui/progress";
+import { Button } from "@/components/pittaya/ui/button";
+import { useState } from "react";
+
+export function MultiStepProgress() {
+  const [currentStep, setCurrentStep] = useState(1);
+  const totalSteps = 4;
+  const progress = (currentStep / totalSteps) * 100;
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <div className="flex justify-between text-sm">
+          <span className="text-muted-foreground">
+            Step {currentStep} of {totalSteps}
+          </span>
+          <span className="font-medium">{Math.round(progress)}%</span>
+        </div>
+        <Progress value={progress} />
+      </div>
+
+      <div className="flex gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => setCurrentStep(Math.max(1, currentStep - 1))}
+          disabled={currentStep === 1}
+        >
+          Previous
+        </Button>
+        <Button
+          size="sm"
+          onClick={() => setCurrentStep(Math.min(totalSteps, currentStep + 1))}
+          disabled={currentStep === totalSteps}
+        >
+          {currentStep === totalSteps ? "Complete" : "Next"}
+        </Button>
+      </div>
+    </div>
+  );
+}`,
+      preview: <MultiStepProgressPreview />,
+    },
+  ],
+  toc: [
+    { id: "installation", title: "Installation", level: 2 },
+    { id: "when-to-use", title: "When to use", level: 2 },
+    { id: "best-practices", title: "Best practices", level: 2 },
+    { id: "accessibility", title: "Accessibility", level: 2 },
+    { id: "examples", title: "Examples", level: 2 },
+    { id: "properties", title: "Properties", level: 2 },
+  ],
+  showcase: {
+    code: `import { Progress } from "@/components/pittaya/ui/progress";
+import { useEffect, useState } from "react";
+
+export function FileUploadProgress() {
+  const [progress, setProgress] = useState(0);
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setProgress((prev) => {
+        if (prev >= 100) {
+          clearInterval(timer);
+          return 100;
+        }
+        return prev + 1;
+      });
+    }, 50);
+
+    return () => clearInterval(timer);
+  }, []);
+
+  return (
+    <div className="space-y-2">
+      <div className="flex justify-between text-sm">
+        <span className="text-muted-foreground">Uploading document.pdf</span>
+        <span className="font-medium">{progress}%</span>
+      </div>
+      <Progress value={progress} />
+      {progress === 100 && (
+        <p className="text-sm text-green-600">Upload complete!</p>
+      )}
+    </div>
+  );
+}`,
+    preview: <FileUploadProgressPreview />,
+  },
+});

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -1,0 +1,42 @@
+import * as ProgressPrimitive from "@radix-ui/react-progress";
+import { cva, type VariantProps } from "class-variance-authority";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const progressVariants = cva(
+  "relative h-2 w-full overflow-hidden rounded-full bg-primary/20",
+  {
+    variants: {
+      variant: {
+        default: "[&>div]:bg-primary",
+        secondary: "[&>div]:bg-secondary",
+        destructive: "[&>div]:bg-destructive",
+        success: "[&>div]:bg-green-600",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+);
+
+const Progress = React.forwardRef<
+  React.ElementRef<typeof ProgressPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root> &
+    VariantProps<typeof progressVariants>
+>(({ className, value, variant, ...props }, ref) => (
+  <ProgressPrimitive.Root
+    ref={ref}
+    className={cn(progressVariants({ variant }), className)}
+    {...props}
+  >
+    <ProgressPrimitive.Indicator
+      className="h-full w-full flex-1 transition-all duration-300 ease-in-out"
+      style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+    />
+  </ProgressPrimitive.Root>
+));
+Progress.displayName = ProgressPrimitive.Root.displayName;
+
+export { Progress, progressVariants };

--- a/src/lib/docs/component-details.tsx
+++ b/src/lib/docs/component-details.tsx
@@ -13,6 +13,7 @@ import { labelDoc } from "@/components/docs/contents/label/label";
 import { multiSelectDoc } from "@/components/docs/contents/multi-select/multi-select";
 import { orbitImagesDoc } from "@/components/docs/contents/orbit-images";
 import { popoverDoc } from "@/components/docs/contents/popover";
+import { progressDoc } from "@/components/docs/contents/progress/progress";
 import { radioGroupDoc } from "@/components/docs/contents/radio-group/radio-group";
 import { selectDoc } from "@/components/docs/contents/select/select";
 import { skeletonDoc } from "@/components/docs/contents/skeleton/skeleton";
@@ -39,6 +40,7 @@ const docs: Record<string, ComponentDoc> = {
   [multiSelectDoc.slug]: multiSelectDoc,
   [orbitImagesDoc.slug]: orbitImagesDoc,
   [popoverDoc.slug]: popoverDoc,
+  [progressDoc.slug]: progressDoc,
   [radioGroupDoc.slug]: radioGroupDoc,
   [selectDoc.slug]: selectDoc,
   [skeletonDoc.slug]: skeletonDoc,

--- a/src/lib/docs/components-index.ts
+++ b/src/lib/docs/components-index.ts
@@ -151,6 +151,16 @@ export const componentsIndex: ComponentIndexItem[] = [
     dependencies: ["@radix-ui/react-popover"],
   },
   {
+    slug: "progress",
+    name: "Progress",
+    description:
+      "Displays an indicator showing the completion progress of a task or operation.",
+    category: "Feedback",
+    status: "stable",
+    tags: ["progress", "indicator", "loading", "status"],
+    dependencies: ["@radix-ui/react-progress"],
+  },
+  {
     slug: "radio-group",
     name: "Radio Group",
     description:


### PR DESCRIPTION
This pull request adds a new **Progress** component to the UI library and integrates full documentation and examples for it. The changes cover the component implementation, interactive usage examples, and updates to the documentation system to properly register and showcase the new component.

## Component Implementation
- Introduced the `Progress` component in `src/components/ui/progress.tsx`, built on top of Radix UI’s progress primitive.
- Supports multiple visual variants (`default`, `secondary`, `destructive`, `success`) to adapt to different semantic contexts and UI needs.

## Documentation and Examples
- Added comprehensive documentation for the Progress component in `src/components/docs/contents/progress/progress.tsx`, including usage guidelines, accessibility considerations, available props, and example snippets with previews.
- Implemented interactive examples in `src/components/docs/contents/progress/progress-examples.tsx`, covering scenarios such as basic progress indication, file upload simulation, multi-step workflows, and variant styling demonstrations.

## Documentation System Integration
- Registered the Progress component documentation in the central docs registry (`src/lib/docs/component-details.tsx`) and included it in the exported documentation map.
- Added the Progress component to the global components index (`src/lib/docs/components-index.ts`), defining its metadata, tags, and dependencies so it can be easily discovered and browsed in the documentation site.
